### PR TITLE
Add drawn bounding boxes

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -67,26 +67,6 @@ class _HomePageState extends State<HomePage> {
                       ),
                     )
                   ],
-                )
-
-                // body: SafeArea(
-                //     child: Center(
-                //         child: Column(children: [
-                //   ElevatedButton(
-                //     onPressed: () async {
-                //       await availableCameras().then((value) => Navigator.push(context,
-                //           MaterialPageRoute(builder: (_) => CameraPage(cameras: value))));
-                //     },
-                //     child: const Text("Capture Image"),
-                //   ),
-                //   ElevatedButton(
-                //     onPressed: () async {
-                //       await availableCameras().then((value) => Navigator.push(
-                //           context, MaterialPageRoute(builder: (_) => ChatbotPage())));
-                //     },
-                //     child: const Text("Chatbot"),
-                //   )
-                // ]))                // ),
-                )));
+                ))));
   }
 }


### PR DESCRIPTION
Draw bounding boxes around detected objects. They are visible on the plant info page. There is no on/off toggle currently.